### PR TITLE
Make a config file optional

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -21,9 +21,9 @@ module.exports = function(grunt) {
     var data = this.data;
     //merge options onto data, with data taking precedence
     data = _.merge(options, data);
-    data.configFile = path.resolve(data.configFile);
 
     if (data.configFile) {
+      data.configFile = path.resolve(data.configFile);
       data.configFile = grunt.template.process(data.configFile);
     }
     //support `karma run`, useful for grunt watch


### PR DESCRIPTION
With karma 0.9+ all parameter could be expressed with strings.
Now it is possible to put the hole config into the Gruntfile.

Only cave head is that the property `files` in a target has a special meaning. You have to wrap all into options object like this:

``` js
karma: {
  options: { // this are parameters for all targets
    port: 9000,
    runnerPort: 9100,
    autoWatch: false,
    logLevel: 'error'
  },
  unit: {
    options: { // this are options for the target
      files: ['src/**/*js']
    }
  }
  e3e: {}  //etc.
}
```

grunt merge the options automatically.
