### PR TITLE
Adds dependencies to new repositories for some karma preprocessors, frameworks and reporters

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "karma": "~0.9.2",
     "karma-ng-html2js-preprocessor": "~0.0.1",
-    "karma-junit-reporter": "~0.0.1"
+    "karma-junit-reporter": "~0.0.1",
+    "karma-ng-scenario": "~0.0.2"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
A recent change in Karma extracts preprocessors and reporters to separate modules. This diff adds the html2js preprocessor, ng-scenario framework and the junit-reporter dependencies to the grunt-karma's packages.json to be able to use them in the most recent grunt-karma version.
