### PR TITLE
make Karma peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "author": "Dave Geddes",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "dependencies": {
-    "karma": "~0.9.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
     "expect.js": "~0.2.0",
@@ -34,6 +32,7 @@
     "karma-mocha": "~0.0.1"
   },
   "peerDependencies": {
-    "grunt": "0.4.x"
+    "grunt": "0.4.x",
+    "karma": "~0.9.4 || ~0.10"
   }
 }


### PR DESCRIPTION
It makes no sense to install two instances of Karma, if the developer wants to use both Karma through grunt-karma and Karma directly.

Also, since Karma 0.9, developers need to install plugins and it is very hard to load plugins if Karma was installed as a dependency of grunt-karma.

The recommended way is to put everything into the `package.json`:

``` json
{
  "devDependencies": {
    "karma": "~0.10",
    "grunt": "~0.4",
    "grunt-karma": "*",
    "karma-mocha": "*"
  }
}
```

Closes #13
