### PR TITLE
Added `loadFiles` option for Grunt config.

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -21,6 +21,8 @@ module.exports = function(grunt) {
     var data = this.data;
     //merge options onto data, with data taking precedence
     data = _.merge(options, data);
+    data.files = data.loadFiles;
+    delete data.loadFiles;
     data.configFile = path.resolve(data.configFile);
 
     if (data.configFile) {


### PR DESCRIPTION
Allows provision of files to be loaded by karma runner in Grunt config,
using `loadFiles` configuration option.

There is some discussion here: https://github.com/karma-runner/grunt-karma/issues/21#issuecomment-22016262

Submitting, just in case, or as a temp. workaround.
