### PR TITLE
Added a wait option to be used in combination with background:true

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -40,17 +40,17 @@ module.exports = function(grunt) {
     //allow karma to be run in the background so it doesn't block grunt
     if (data.background){
       var callback = function() {};
+      var opts = {};
       //if wait option is on run karma in the background but wait for it to finish before continuing task execution
       //avoids having multiple karma servers running if running more than once in the same task queue
-      if(data.wait){
+      if (data.wait) {
+        opts = {stdio: 'inherit'};
         callback = function(error, result, code) {
-          grunt.log.writeln(result.stdout);
-          if(result.stderr) grunt.warn(result.stderr);
           done(code === 0);
         };
       }
 
-      grunt.util.spawn({cmd: 'node', args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]}, callback);
+      grunt.util.spawn({cmd: 'node', opts: opts, args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)] }, callback);
 
       //finish immediately
       if (!data.wait) done();


### PR DESCRIPTION
This allows you to run several karma tasks in the same queue without getting multiple "port in use" warning. 

https://travis-ci.org/mokkabonna/knockout.bindingHandlers.number#L2335

Also causes possible eventemitter memory leak warnings

https://travis-ci.org/mokkabonna/knockout.bindingHandlers.number#L2174

This would preferrably be implemented without needing it to run in the background. If karma [supported being stopping](https://github.com/karma-runner/karma/issues/136) without the whole process exiting then you could implement it like so:

```
server.start(data, function(code){
    server.stop();
    done(code === 0);
});
```

You would also get the benefit of getting the output from karma as it comes, not all at once like now with this wait option.

But until then I hope this is something you could want to merge. 

If so let me know and I'll add the docs for the wait option as well.
