### PR TITLE
Kill background child process on main process exit

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -39,7 +39,10 @@ module.exports = function(grunt) {
     
     //allow karma to be run in the background so it doesn't block grunt
     if (data.background){
-      grunt.util.spawn({cmd: 'node', args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]}, function(){});
+      var backgroundProcess = grunt.util.spawn({cmd: 'node', args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]}, function(){});
+      process.on('exit', function () {
+        backgroundProcess.kill();
+      });
       done();
     }
     else {


### PR DESCRIPTION
The instructions for using grunt-karma with `background:true` indicate the need to have a `watch` task that runs, for example, the `karma:unit:run` task when a watched file changes (via `$ grunt karma:unit watch`).

This makes sense, but we were finding that if `karma:unit` was run without calling the `watch` task afterwards then Grunt was exiting immediately with a success code and the background process created by grunt-karma wasn't exiting.

Obviously we could avoid this problem by making sure that the `karma:unit` task was never run independently, but mistakes happen. The changes in this pull request will kill the background process on the process's 'exit' event.
