### PR TITLE
Print log when in background mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ karma: {
   }
 }
 ```
-The `background` option will tell grunt to run karma in a child process so it doesn't block subsequent grunt tasks.
+The `background` option will tell grunt to run karma in a child process so it doesn't block subsequent grunt tasks. You can add `silent: true` to supress output from the background process.
 
 Config your `watch` task to run the karma task with the `:run` flag. For example:
 

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
     var done = this.async();
     var options = this.options({
       background: false,
+      silent: false,
       // allow passing of cli args on as client args, for example --grep=x
       clientArgs: require('optimist').argv,
       client: { args: require('optimist').argv }
@@ -39,10 +40,14 @@ module.exports = function(grunt) {
     
     //allow karma to be run in the background so it doesn't block grunt
     if (data.background){
+      var spawnOpts = {stdio: 'ignore'}
+      if (!data.silent)
+        spawnOpts.stdio = 'inherit'
+
       grunt.util.spawn({
         cmd: 'node',
         args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)],
-        opts: {stdio: 'inherit'}
+        opts: spawnOpts
       }, function(){});
       done();
     }


### PR DESCRIPTION
Now we can see errors and stuff. One could also add a `silent` or only inherit `stderr`, but I decided to keep it simple.
