### PR TITLE
grunt.util._ is deprecated - replace it with lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "optimist": "~0.6.0"
+    "optimist": "~0.6.0",
+    "lodash": "~2.4.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -10,9 +10,9 @@ var runner = require('karma').runner;
 var server = require('karma').server;
 var path = require('path');
 var optimist = require('optimist');
+var _ = require('lodash');
 
 module.exports = function(grunt) {
-  var _ = grunt.util._;
 
   grunt.registerMultiTask('karma', 'run karma.', function() {
     var done = this.async();


### PR DESCRIPTION
Per http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released, grunt.util._ is deprecated, but Lodash is a drop-in replacement since that's all grunt.util._ was anyway.
