### PR TITLE
Temporarily remove Grunt's uncaughtException listeners.

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -75,6 +75,10 @@ module.exports = function(grunt) {
       done();
     }
     else {
+      //listen for SIGINT and take care of stopping the process *after* karma
+      //stopped all browsers
+      var sigint = false;
+      process.on('SIGINT', function() { sigint = true; });
       //temporarily remove Grunt's uncaughtException listener, so that
       //karma can handle these and stop any running browsers
       var uncaughtListeners = process.listeners('uncaughtException');
@@ -83,6 +87,9 @@ module.exports = function(grunt) {
       function resetListeners(result) {
         uncaughtListeners.forEach(process.on.bind(process, 'uncaughtException'));
         done(result);
+        if( sigint ) {
+          process.exit(130);
+        }
       }
 
       server.start(data, finished.bind(resetListeners));

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -75,7 +75,17 @@ module.exports = function(grunt) {
       done();
     }
     else {
-      server.start(data, finished.bind(done));
+      //temporarily remove Grunt's uncaughtException listener, so that
+      //karma can handle these and stop any running browsers
+      var uncaughtListeners = process.listeners('uncaughtException');
+      process.removeAllListeners('uncaughtException');
+
+      function resetListeners(result) {
+        uncaughtListeners.forEach(process.on.bind(process, 'uncaughtException'));
+        done(result);
+      }
+
+      server.start(data, finished.bind(resetListeners));
     }
   });
 };

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -78,7 +78,8 @@ module.exports = function(grunt) {
       //listen for SIGINT and take care of stopping the process *after* karma
       //stopped all browsers
       var sigint = false;
-      process.on('SIGINT', function() { sigint = true; });
+      var sigintListener = function() { sigint = true };
+      process.on('SIGINT', sigintListener);
       //temporarily remove Grunt's uncaughtException listener, so that
       //karma can handle these and stop any running browsers
       var uncaughtListeners = process.listeners('uncaughtException');
@@ -86,6 +87,7 @@ module.exports = function(grunt) {
 
       function resetListeners(result) {
         uncaughtListeners.forEach(process.on.bind(process, 'uncaughtException'));
+        process.removeListener('SIGINT', sigintListener);
         done(result);
         if( sigint ) {
           process.exit(130);


### PR DESCRIPTION
As I mentioned in #93, Grunt's `uncaughtException` listeners fire before Karma gets a chance to stop the browsers it started.

The only fix that I can think of is removing Grunt's listners for as long as Karma is running. That way, Karma can gracefully handle a framework raising an error or the user pressing Ctrl-c.

I made a small gist to reproduce the problem: https://gist.github.com/jpommerening/10364033

After running `npm install`, running Grunt will (probably) produce the following output:

``` console
$ grunt
Running "karma:unicorns" (karma) task
INFO [karma]: Karma v0.12.6 server started at http://localhost:9876/
INFO [launcher]: Starting browser PhantomJS
INFO [PhantomJS 1.9.7 (Linux)]: Connected on socket 8mpKEfFNXoO5vMb1GWU6 with id 2679007
PhantomJS 1.9.7 (Linux): Executed 1 of 1 SUCCESS (0.038 secs / 0 secs)

Running "karma:explosions" (karma) task
INFO [karma]: Karma v0.12.6 server started at http://localhost:9876/
INFO [launcher]: Starting browser PhantomJS
INFO [PhantomJS 1.9.7 (Linux)]: Connected on socket uo1f5cVKNpntcOFnGWd8 with id 10877927
PhantomJS 1.9.7 (Linux): Executed 1 of 1 SUCCESS (0.039 secs / 0 secs)
Fatal error: Bam!
```

To try the same thing with the changes in this PR:

``` console
$ npm install grunt-karma@jpommerening/grunt-karma#fix-stray-browsers
...
$ grunt
...
```
