### PR TITLE
flatten files option as typical in grunt plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ karma: {
 To change the `logLevel` in the grunt config file instead of the karma config, use one of the following strings:
 `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`
 
+### Config with Grunt Template Strings in `files`
+
+When using template strings in the `files` option, the results will flattened. Therefore, if you include a variable that includes an array, the array will be flattened before being passed to Karma.
+
+Example:
+
+```js
+meta: {
+  jsFiles: ['jquery.js','angular.js']
+},
+karma: {
+  options: {
+    files: ['<%= meta.jsFiles %>','angular-mocks.js','**/*-spec.js']
+  }
+}
+```
+
 ## Sharing Configs
 If you have multiple targets, it may be helpful to share common
 configuration settings between them. Grunt-karma supports this by

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -56,6 +56,10 @@ module.exports = function(grunt) {
       data.configFile = grunt.template.process(data.configFile);
     }
 
+    if (data.files){
+      data.files = _.flatten(data.files);
+    }
+
     //support `karma run`, useful for grunt watch
     if (this.flags.run){
       runner.run(data, finished.bind(done));


### PR DESCRIPTION
Since grunt-karma doesn't allow grunt to handle the source files using the standard Grunt way, you loose the automatic array flattening.  This is useful when referencing other vars in your files array (and those vars are themselves arrays).  This has happened to use in cgross/generator-cg-angular#23.  

 I think changing grunt-karma to be a good acting grunt plugin by using the standard fileSrc would be best (ala #60).  But that will require breaking changes to how users specify their options.  This change does not go that far and thus can be applied with no compatibility problems.
