### PR TITLE
Make process exit on test failure configurable

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('karma', 'run karma.', function() {
     var done = this.async();
     var options = this.options({
-      background: false
+      background: false,
+      exitOnFailure: true
     });
 
     if (!options.client) {
@@ -75,7 +76,11 @@ module.exports = function(grunt) {
       done();
     }
     else {
-      server.start(data, finished.bind(done));
+      if(data.exitOnFailure){
+        server.start(data, finished.bind(done));
+      }else{
+        server.start(data, done);
+      }
     }
   });
 };


### PR DESCRIPTION
We run multiple grunt-karma executions that test large data sets.  If one fails, we do not wish to halt the execution of the rest, therefore, we have made this configurable.
