### PR TITLE
Make process exit on test failure configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ directly in the Gruntfile:
 ```js
 karma: {
   unit: {
+    exitOnFailure: false,
     configFile: 'karma.conf.js',
     runnerPort: 9999,
     singleRun: true,
@@ -60,6 +61,8 @@ karma: {
   }
 }
 ```
+
+The 'exitOnFailure' config property when false, will continue executing grunt tasks instead of having karma exit the process (warning: when set to false and running with multiple grunt tasks, the build will not be considered a 'failure' even if some tests failed).  The default value is true.  A value of true will exit the process on test failures and halt any further grunt executions.
 
 To change the `logLevel` in the grunt config file instead of the karma config, use one of the following strings:
 `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('karma', 'run karma.', function() {
     var done = this.async();
     var options = this.options({
-      background: false
+      background: false,
+      exitOnFailure: true
     });
 
     if (!options.client) {
@@ -75,7 +76,11 @@ module.exports = function(grunt) {
       done();
     }
     else {
-      server.start(data, finished.bind(done));
+      if (data.exitOnFailure) {
+        server.start(data, finished.bind(done));
+      } else {
+        server.start(data, done);
+      }
     }
   });
 };


### PR DESCRIPTION
We run multiple grunt-karma executions that test large data sets. If one fails, we do not wish to halt the execution of the rest, therefore, we have made this configurable.