### PR TITLE
#10 #49 debug for background process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.9.0 (2014-09-04)
+
+## Features
+### conventional-changelog
+
+* add conventional-changelog (72c67e3)
+
+### karma-dependency
+
+* Bump Karma depdency to ~0.9.2 (23a4f25)
+
+### 
+
+* make configFile optional (cee07ab)
+
+
+
+
 # 0.8.3
 * Flatten `files` input (@cgross)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# grunt-karma [![Build Status](https://travis-ci.org/karma-runner/grunt-karma.svg?branch=master)](https://travis-ci.org/karma-runner/grunt-karma)
+# grunt-karma [![Build Status](https://travis-ci.org/karma-runner/grunt-karma.svg?branch=master)](https://travis-ci.org/karma-runner/grunt-karma) [![Dependency Status](https://david-dm.org/karma-runner/grunt-karma.svg)](https://david-dm.org/karma-runner/grunt-karma) [![devDependency Status](https://david-dm.org/karma-runner/grunt-karma/dev-status.svg)](https://david-dm.org/karma-runner/grunt-karma#info=devDependencies)
+
 
 > Grunt plugin for [Karma](https://github.com/karma-runner/karma)
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,16 @@ karma: {
     runnerPort: 9999,
     singleRun: true,
     browsers: ['PhantomJS'],
-    logLevel: 'ERROR'
+    logLevel: 'ERROR',
+    debug: true
   }
 }
 ```
 
 To change the `logLevel` in the grunt config file instead of the karma config, use one of the following strings:
 `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`
+
+Setting the debug option to true will cause the karma output to be printed.
 
 ### Config with Grunt Template Strings in `files`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > Grunt plugin for [Karma](https://github.com/karma-runner/karma)
 
-This current version `0.8.0` uses `karma@0.12.x`. For using older versions see the
+This current version uses `karma@0.12.x`. For using older versions see the
 old releases of grunt-karma.
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-karma",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "grunt plugin for karma test runner",
   "main": "tasks/grunt-karma.js",
   "repository": {

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -66,17 +66,24 @@ module.exports = function(grunt) {
       return;
     }
 
+
     //allow karma to be run in the background so it doesn't block grunt
     if (data.background){
-      var backgroundArgs = {
+      var opts = {
         cmd: 'node',
         args: process.execArgv.concat([path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)])
-      };
-      var backgroundProcess = grunt.util.spawn(backgroundArgs, function(error){
+      }
+
+      if (grunt.log.option('debug')) {
+        opts.opts = {stdio: 'inherit'}
+      }
+
+      var backgroundProcess = grunt.util.spawn(opts, function(error){
         if (error) {
           grunt.log.error(error);
         }
       });
+
       process.on('exit', function () {
         backgroundProcess.kill();
       });


### PR DESCRIPTION
This change will print output of the spawned process when the grunt --debug flag is used.

I think this will clear up much of the confusion around using background since there are many scenarios where the grunt.util.spawn can fail without any indication of error.

Similar to PR #10 but without the change to the user facing configuration options.
