### PR TITLE
Add singleRun option in Grunt Watch Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,16 @@ Config karma like usual (without the autoWatch option), and add
 karma: {
   unit: {
     configFile: 'karma.conf.js',
-    background: true
+    background: true,
+    singleRun: false
   }
 }
 ```
 The `background` option will tell grunt to run karma in a child process
 so it doesn't block subsequent grunt tasks.
+
+The `singleRun: false` option will tell grunt to keep the karma server up
+after a test run.
 
 Config your `watch` task to run the karma task with the `:run` flag. For example:
 


### PR DESCRIPTION
This is a proposal for fixing issue #49

Specifying the `singleRun: false` option in Grunt Watch Session to ensure people get the example working even if the karma config file specify `singleRun: true`. With singleRun set to true, the example will fail because the server is stopped after each test run.
