### PR TITLE
fix: Log errors in the background subprocess

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -68,7 +68,15 @@ module.exports = function(grunt) {
 
     //allow karma to be run in the background so it doesn't block grunt
     if (data.background){
-      var backgroundProcess = grunt.util.spawn({cmd: 'node', args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]}, function(){});
+      var backgroundArgs = {
+        cmd: 'node',
+        args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]
+      };
+      var backgroundProcess = grunt.util.spawn(backgroundArgs, function(error){
+        if (error) {
+          grunt.log.error(error);
+        }
+      });
       process.on('exit', function () {
         backgroundProcess.kill();
       });


### PR DESCRIPTION
Currently there is not output if the background subprocess exits with an error,
for example because the configuration file has a syntax error. This commit fixes
that.

Should I add tests for it?
