### PR TITLE
fix: Pass node-specific command line params to the subprocess

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
     if (data.background){
       var backgroundArgs = {
         cmd: 'node',
-        args: [path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)]
+        args: process.execArgv.concat([path.join(__dirname, '..', 'lib', 'background.js'), JSON.stringify(data)])
       };
       var backgroundProcess = grunt.util.spawn(backgroundArgs, function(error){
         if (error) {


### PR DESCRIPTION
fix: Pass node-specific command line params to the subprocess

This commit makes the karma task pass Node-specific parameters used to start
the Node process to its background subprocess. This is required e.g. to be able
to use the `--harmony` flag.

Similar pull request for Grunt itself (already merged):
https://github.com/gruntjs/grunt/pull/877

Should I add tests for it?

EDIT: Note that they aren't _all_ parameters, only Node-specific ones. That's why it's safe. All params lie in `process.argv` not `process.execArgv`.
