### PR TITLE
chore: Pass Node versions as strings to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - '0.8'
+  - '0.10'
 
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
Node versions, as most versions, are strings, not numbers. 0.10 as a number
equals 0.1 which by the virtue of nvm is matched as 0.10 but shouldn't be
relied upon. Also, it screws Node numbering in Travis runs, see e.g.:
https://travis-ci.org/karma-runner/grunt-karma/builds/28585432
