### PR TITLE
Use Grunt's file resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,36 @@ karma: {
 To change the `logLevel` in the grunt config file instead of the karma config, use one of the following strings:
 `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`
 
+The `files` option can be extended "per-target" in the typical way
+Grunt handles [files][grunt-config-files]:
+
+```js
+karma: {
+  options: {
+    files: ['lib/**/*.js']
+  },
+  unit: {
+    files: [
+      { src: ['test/**/*.js'] }
+    ]
+  }
+}
+```
+
+When using the "Grunt way" of specifying files, you can also extend the
+file objects with the options [supported by karma][karma-config-files]:
+
+```js
+karma: {
+  unit: {
+    files: [
+      { src: ['test/**/*.js'], served: true },
+      { src: ['lib/**/*.js'], served: true, included: false }
+    ]
+  }
+}
+```
+
 ### Config with Grunt Template Strings in `files`
 
 When using template strings in the `files` option, the results will flattened. Therefore, if you include a variable that includes an array, the array will be flattened before being passed to Karma.
@@ -195,7 +225,9 @@ $ grunt karma:dev watch --grep=mypattern
 ## License
 MIT License
 
-[karma-config-file]: http://karma-runner.github.com/0.8/config/configuration-file.html
+[karma-config-file]: http://karma-runner.github.com/0.12/config/configuration-file.html
+[karma-config-files]: http://karma-runner.github.io/0.12/config/files.html
+[grunt-config-files]: http://gruntjs.com/configuring-tasks#files
 [grunt-contrib-watch]: https://github.com/gruntjs/grunt-contrib-watch
 [PhantomJS]: http://phantomjs.org/
 [karma-mocha]: https://github.com/karma-runner/karma-mocha

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -16,12 +16,11 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('karma', 'run karma.', function() {
     var done = this.async();
     var options = this.options({
-      background: false
+      background: false,
+      files: [],
+      client: {}
     });
 
-    if (!options.client) {
-        options.client = {};
-    }
     // Allow for passing cli arguments to `client.args` using  `--grep=x`
     var args = parseArgs(process.argv.slice(2));
     if (_.isArray(options.client.args)) {
@@ -56,9 +55,17 @@ module.exports = function(grunt) {
       data.configFile = grunt.template.process(data.configFile);
     }
 
-    if (data.files){
-      data.files = _.flatten(data.files);
-    }
+    data.files = [].concat.apply(options.files, this.files.map(function(file) {
+      return file.src.map(function(src) {
+        var obj = { pattern: src };
+        ['watched', 'served', 'included'].forEach(function(opt) {
+          if (opt in file) {
+            obj[opt] = file[opt];
+          }
+        });
+        return obj;
+      });
+    }));
 
     //support `karma run`, useful for grunt watch
     if (this.flags.run){


### PR DESCRIPTION
`grunt-karma` should leave the file globbing to Grunt _and_ it should support Karma's file [options](http://karma-runner.github.io/0.12/config/files.html) for watching files, including them, etc..

The former was first suggested in #60, but did not make it into `master`. The latter, well there is #51, but tl;dr and _oh god, it's full of diffs_ :sparkles:.

I implemented this by appending the files that are specified "[the Grunt way](http://gruntjs.com/configuring-tasks#files)" (`this.files[0..n].src`) to the files specified via `options.files`.

For each object `{src: [...]}` in `this.files[0..n]` the code generates an array containing file objects, that may optionally have `included`, `watched` and/or `served` set and finally concats/flattens them to `options.files` ([here](122/files#diff-a6d84f8e02b7bd2abf8354f465508f43R58)):
```js
options: {
  files: ['index.js']
},
target: {
  files: [
    { src: 'test/**/*.js' },
    { src: 'lib/**/*.js', included: false }
  ]
}
/* becomes */
files = [
  'index.js',
  { pattern: 'test/file1.js' },
  { pattern: 'test/file2.js' },
  // ...
  { pattern: 'lib/file1.js', included: false },
  { pattern: 'lib/file2.js', included: false },
  // ...
];
```