### PR TITLE
Feature: Process templates in preprocessors config

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -60,6 +60,18 @@ module.exports = function(grunt) {
       data.files = _.flatten(data.files);
     }
 
+    // Allow the use of templates in preprocessors
+    if (_.isPlainObject(data.preprocessors)) {
+      var preprocessors = {};
+      Object.keys(data.preprocessors).forEach(function (key) {
+        var value = data.preprocessors[key];
+        key = path.resolve(key);
+        key = grunt.template.process(key);
+        preprocessors[key] = value;
+      });
+      data.preprocessors = preprocessors;
+    }
+
     //support `karma run`, useful for grunt watch
     if (this.flags.run){
       runner.run(data, finished.bind(done));

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -53,7 +53,6 @@ module.exports = function(grunt) {
 
     if (data.configFile) {
       data.configFile = path.resolve(data.configFile);
-      data.configFile = grunt.template.process(data.configFile);
     }
 
     if (data.files){


### PR DESCRIPTION
Hey Folks,

like many other people I use lodash templates in my Grunt configuration to manage directory names, filenames and other things like ``package.json`` information for reuse.

Example:

    grunt.initConfig({
        dir: {
            lib: 'lib',
            test: 'test',
            unit: '<%= dir.test %>/unit'
        },
        jsFiles: [
            '<%= dir.lib %>/**/*.js',
            '<%= dir.unit %>/**/*.js',
            'Gruntfile.js',
            'index.js'
        ],
        eslint: {
            all: '<%= jsFiles %>'
        }
    });

In **grunt-karma** it's possible for the ``files``and ``configFile`` configuration, but not for ``preprocessors``, which is an object with keys of files:

    preprocessors: {
        '<%= dir.unit %>/**/*.js': [
            'browserify'
        ]
    }

It would be nice if this gets merged.