### PR TITLE
Only pass client config to karma if it is really defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.9.0 (2014-09-04)
+
+## Features
+### conventional-changelog
+
+* add conventional-changelog (72c67e3)
+
+### karma-dependency
+
+* Bump Karma depdency to ~0.9.2 (23a4f25)
+
+### 
+
+* make configFile optional (cee07ab)
+
+
+
+
 # 0.8.3
 * Flatten `files` input (@cgross)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# grunt-karma [![Build Status](https://travis-ci.org/karma-runner/grunt-karma.svg?branch=master)](https://travis-ci.org/karma-runner/grunt-karma)
+# grunt-karma [![Build Status](https://travis-ci.org/karma-runner/grunt-karma.svg?branch=master)](https://travis-ci.org/karma-runner/grunt-karma) [![Dependency Status](https://david-dm.org/karma-runner/grunt-karma.svg)](https://david-dm.org/karma-runner/grunt-karma) [![devDependency Status](https://david-dm.org/karma-runner/grunt-karma/dev-status.svg)](https://david-dm.org/karma-runner/grunt-karma#info=devDependencies)
+
 
 > Grunt plugin for [Karma](https://github.com/karma-runner/karma)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > Grunt plugin for [Karma](https://github.com/karma-runner/karma)
 
-This current version `0.8.0` uses `karma@0.12.x`. For using older versions see the
+This current version uses `karma@0.12.x`. For using older versions see the
 old releases of grunt-karma.
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-karma",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "grunt plugin for karma test runner",
   "main": "tasks/grunt-karma.js",
   "repository": {

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -19,23 +19,29 @@ module.exports = function(grunt) {
       background: false
     });
 
-    if (!options.client) {
-        options.client = {};
-    }
     // Allow for passing cli arguments to `client.args` using  `--grep=x`
     var args = parseArgs(process.argv.slice(2));
-    if (_.isArray(options.client.args)) {
-        options.client.args = options.client.args.concat(args);
-    } else {
-        options.client.args = args;
+    if (options.client && _.isArray(options.client.args)) {
+      args = options.client.args.concat(args);
     }
 
-    // Merge karma default options
-    _.defaults(options.client, {
+    // If arguments are provided we pass them to karma
+    if (args.length > 0) {
+      if (!options.client) {
+        options.client = {};
+      }
+      options.client.args = args;
+    }
+
+    //Only create client info if data is provided
+    if (options.client) {
+      // Merge karma default options
+      _.defaults(options.client, {
         args: [],
         useIframe: true,
         captureConsole: true
-    });
+      });
+    }
 
     var opts = _.cloneDeep(options);
     // Merge options onto data, with data taking precedence.


### PR DESCRIPTION
Only pass client config to karma if it really defined in the grunt config

If the client object is always passed to karma, config of the configFile is overwritten.

Fixes: https://github.com/karma-runner/grunt-karma/issues/119