### PR TITLE
Update grunt-karma.js

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -82,6 +82,7 @@ module.exports = function(grunt) {
           return obj;
         });
       }));
+      data.files = _.flatten(data.files);
     }
 
     // Allow the use of templates in preprocessors


### PR DESCRIPTION
Fix for bug: arguments to path.resolve must be strings #142

I changed the grunt-karma.js file by adding `data.files =_.flatten(data.files);` to line 85.  The _.flatten used to be there in the 0.9 version and the [].concat is not flattening like it should on my machine.

To test it pass `files: [['a.js','b.js','c.js'],'d.js','e.js']` under karma -> options -> files in the config and it will break then add the line of code and it will work.