### PR TITLE
peerDependencies in npm 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "grunt": "0.4.x",
+    "karma": "~0.12.0"
   },
   "devDependencies": {
     "coffee-script": "~1.8.0",
     "expect.js": "^0.3.1",
-    "grunt": "~0.4.3",
     "grunt-auto-release": "0.0.6",
     "grunt-bump": "0.0.16",
     "grunt-contrib-jshint": "~0.10.0",
@@ -40,10 +41,6 @@
     "karma-chrome-launcher": "~0.1.2",
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "~0.1.3"
-  },
-  "peerDependencies": {
-    "grunt": "0.4.x",
-    "karma": "~0.12.0"
   },
   "contributors": [
     "dignifiedquire <friedel.ziegelmayer@gmail.com>",


### PR DESCRIPTION
The peer dependency karma@~0.12.0 included from grunt-karma will no longer be automatically installed to fulfill the peerDependency in npm 3+. Your application will need to depend on it explicitly.