### PR TITLE
Updating grunt-karma to use the new API interface from Karma

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,4 +1,5 @@
-var server = require('karma').server
+var Server = require('karma').Server
 var data = JSON.parse(process.argv[2])
+var server = new Server(data)
 
 server.start(data)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-conventional-changelog": "~1.2.2",
     "grunt-eslint": "^13.0.0",
     "grunt-npm": "0.0.2",
-    "karma": "~0.12.0",
+    "karma": "~0.13.0",
     "karma-chrome-launcher": "~0.1.2",
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "~0.1.3",
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "grunt": "0.4.x",
-    "karma": "^0.12 || >= 0.13.0-rc.0"
+    "karma": "^0.13.0 || >= 0.14.0-rc.0"
   },
   "contributors": [
     "Dave Geddes <davidcgeddes@gmail.com>",

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -7,7 +7,7 @@
  */
 
 var runner = require('karma').runner
-var server = require('karma').server
+var Server = require('karma').Server
 var path = require('path')
 var _ = require('lodash')
 
@@ -129,7 +129,8 @@ module.exports = function (grunt) {
 
       done()
     } else {
-      server.start(data, finished.bind(done))
+      var server = new Server(data, finished.bind(done))
+      server.start()
     }
   })
 }


### PR DESCRIPTION
There is a [breaking change](https://github.com/karma-runner/karma/blob/master/CHANGELOG.md#breaking-changes) in Karma#0.13.0 causing grunt-karma to fail. This commit addresses that change in Karma's API interface.

I believe this happened because karma is set as a peerDependency using `^0.12 || >= 0.13.0-rc.0`.

Thanks a lot for your work on this repo!