### PR TITLE
fix(task): prevent `spawn ENAMETOOLONG` on Windows

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,5 +1,6 @@
 var Server = require('karma').Server
-var data = JSON.parse(process.argv[2])
-var server = new Server(data)
-
-server.start(data)
+process.stdin.on('readable', function () {
+  var data = JSON.parse(process.stdin.read())
+  var server = new Server(data)
+  server.start(data)
+})

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -111,18 +111,20 @@ module.exports = function (grunt) {
 
     // allow karma to be run in the background so it doesn't block grunt
     if (data.background) {
-      var backgroundArgs = {
-        cmd: 'node',
-        args: process.execArgv.concat([
+
+      var backgroundProcess = require('child_process').fork(
           path.join(__dirname, '..', 'lib', 'background.js'),
-          JSON.stringify(data)
-        ])
-      }
-      var backgroundProcess = grunt.util.spawn(backgroundArgs, function (error) {
+          { silent: true }
+      )
+      backgroundProcess.stdin.write(JSON.stringify(data))
+
+      backgroundProcess.on('close', function (code) {
+        var error = code
         if (error) {
-          grunt.log.error(error)
+          grunt.log.error('background karma process exited with error (code: ' + code + ')')
         }
       })
+
       process.on('exit', function () {
         backgroundProcess.kill()
       })


### PR DESCRIPTION
As grunt.util.spawn is deprecated (see https://github.com/gruntjs/grunt-legacy-util/blob/621563dd8f6966af39546991bb8d710146430b79/README.md), we might as well switch to native node api. I've chosen child_process.fork() because it avoids looking for the correct node executable on windows (compare https://github.com/gruntjs/grunt-legacy-util/blob/621563dd8f6966af39546991bb8d710146430b79/index.js#L168-L173)

#Closes 161