### PR TITLE
Added important installation information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ old releases of grunt-karma.
 
 ## Getting Started
 From the same directory as your project's Gruntfile and package.json, install
-this plugin with the following command:
+karma and grunt-karma with the following commands:
 
 ```bash
+$ npm install karma --save-dev
 $ npm install grunt-karma --save-dev
 ```
 


### PR DESCRIPTION
Most users that start using grunt-karma follow the "Getting Started" guide. However an important information is missing: karma is required for grunt-karma. This is not trivial as about 10,000 views of [this related topic](http://stackoverflow.com/questions/19203051/cannot-find-module-karma-while-using-grunt) shows.