### PR TITLE
Use Node's built-in message channel for the background server

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -87,6 +87,16 @@ module.exports = function (grunt) {
           }
         ]
       },
+      background: {
+        background: true,
+        files: [
+          {
+            src: 'node_modules/expect.js/index.js'
+          }, {
+            src: 'test/**/*.js'
+          }
+        ]
+      },
       config: {
         configFile: 'karma.conf.js',
         singleRun: true
@@ -114,6 +124,11 @@ module.exports = function (grunt) {
       tests: {
         files: 'test/**/*.js',
         tasks: ['karma:dev:run']
+      },
+      bgtest: {
+        // This is just to stop node exiting
+        files: 'test/**/*.js',
+        tasks: []
       }
     }
   })
@@ -123,6 +138,7 @@ module.exports = function (grunt) {
 
   grunt.registerTask('test', ['karma:single', 'karma:config', 'karma:merge'])
   grunt.registerTask('default', ['eslint', 'test'])
+  grunt.registerTask('bgtest', ['karma:background', 'watch:bgtest'])
 
   grunt.registerTask('release', 'Bump the version and publish to npm.', function (type) {
     grunt.task.run([

--- a/lib/background.js
+++ b/lib/background.js
@@ -1,6 +1,6 @@
 var Server = require('karma').Server
-process.stdin.on('readable', function () {
-  var data = JSON.parse(process.stdin.read())
-  var server = new Server(data)
-  server.start(data)
+
+process.on('message', function (data) {
+  var server = new Server(data.config)
+  server.start()
 })

--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -112,10 +112,8 @@ module.exports = function (grunt) {
     // allow karma to be run in the background so it doesn't block grunt
     if (data.background) {
       var backgroundProcess = require('child_process').fork(
-          path.join(__dirname, '..', 'lib', 'background.js'),
-          { silent: true }
+          path.join(__dirname, '..', 'lib', 'background.js')
       )
-      backgroundProcess.stdin.write(JSON.stringify(data))
 
       backgroundProcess.on('close', function (code) {
         var error = code
@@ -128,6 +126,7 @@ module.exports = function (grunt) {
         backgroundProcess.kill()
       })
 
+      backgroundProcess.send({ config: data })
       done()
     } else {
       var server = new Server(data, finished.bind(done))


### PR DESCRIPTION
After using `client_process.fork`, the parent and child processes can call `send` to fire a `message` event on the other side. This allows us to send arbitrary objects - such as a very large config - to the other process. This is more robust than communicating via `stdin`.

Since it's no longer necessary to redirect `stdin`, I have removed the `silent` option. This means the `karma` output appears in the console window/tty that `grunt` was run from. We might need a separate option to control whether the output goes to that console or to.

Tested on Node.js 4.2.4 and 0.12.1 on Windows 7 SP1 x64. Run `grunt bgtest` to test. I couldn't see an obvious way to automate testing, since the whole point is to launch karma in the background and leave it running.

I started looking into this due to issue #174.