### PR TITLE
fix: remove Grunt peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "load-grunt-tasks": "^3.2.0"
   },
   "peerDependencies": {
-    "grunt": "0.4.x",
     "karma": "^0.13.0 || >= 0.14.0-rc.0"
   },
   "contributors": [


### PR DESCRIPTION
We are removing peerDeps because they are going away in npm and block install in npm 2.
If this is kept in package.json when Grunt 1.0 releases then the plugin won't install in npm 2. 

cc @shama

Ref: https://github.com/gruntjs/grunt/issues/1116