### PR TITLE
fix: rm hardcoded useIframe & captureConsole opts

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -49,9 +49,7 @@ module.exports = function (grunt) {
     if (options.client) {
       // Merge karma default options
       _.defaults(options.client, {
-        args: [],
-        useIframe: true,
-        captureConsole: true
+        args: []
       })
     }
 


### PR DESCRIPTION
These default options will override karma.conf.js even if they're explicitly set to false in there. This was kinda pointless anyway since Karma defaults these options to true anyway if they are not set.

Closes #165, #166