### PR TITLE
Relax peerDependency on Grunt to include v1.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mocha": "^2.4.5"
   },
   "peerDependencies": {
-    "grunt": ">=0.4.x",
+    "grunt": ">=0.4.x || ^1.0.0",
     "karma": "^0.13.0 || ^1.0.0"
   },
   "contributors": [


### PR DESCRIPTION
This fixes an `npm WARN` when installing this package with Grunt 1.x