### PR TITLE
Ensure proper path format

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
       Object.keys(data.preprocessors).forEach(function (key) {
         var value = data.preprocessors[key]
         if (options.basePath) {
-          key = options.basePath + key
+          key = path.join(options.basePath, key)
         }
         key = path.resolve(key)
         key = grunt.template.process(key)


### PR DESCRIPTION
Please make sure that your commit messages follow our [convention](http://karma-runner.github.io/latest/dev/git-commit-msg.html)!

path.join will take care of unneccessary delimiters, that may occur if the given pathes or if for instance 

```
options.basePath = some/path 
```
and
```
key = another/path
```

produces "some/path/another/path" instead of "some/pathanother/path"