### PR TITLE
fix(dependencies): update lodash version to fix npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "lodash": "^4.13.1"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "eslint": "^2.13.1",


### PR DESCRIPTION
Grunt-karma has a vulnerability issue with the current version of lodash. This is a patch to update this version.
(@jtheoof)