### PR TITLE
chore(Travis): Update node versions tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
+  - 8
+  - 10
   - stable
-  - 5
-  - 4
-  - "0.12"
-  - "0.10"
 
 # Make sure we have new NPM.
 before_install:


### PR DESCRIPTION
Synchronise with karma itself, but retaining `stable` for now. This
should unbreak the repo so that other patches can be merged; right
now, Travis fails against these EOLed build targets.