### PR TITLE
feat(karma): require karma 3 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "grunt": ">=0.4.x || ^1.0.0",
-    "karma": "^0.13.0 || ^1.0.0"
+    "karma": "^3.0.0"
   },
   "contributors": [
     "Dave Geddes <davidcgeddes@gmail.com>",


### PR DESCRIPTION
The next release of grunt-karma will not support being used as
wrapper to run karma 1 or older.

This follows 19551fdd83 which updates the tests to use karma 3.

Ref #261.