### PR TITLE
feat: support for type attribute on files

### DIFF
--- a/tasks/grunt-karma.js
+++ b/tasks/grunt-karma.js
@@ -86,7 +86,7 @@ module.exports = function (grunt) {
           let obj = {
             pattern: src
           };
-          ['watched', 'served', 'included'].forEach((opt) => {
+          ['watched', 'served', 'included', 'type'].forEach((opt) => {
             if (opt in file) {
               obj[opt] = file[opt]
             }


### PR DESCRIPTION
This small change adds support to natively run tests written as ES6 modules (without preprocessors) just by adding `type: 'module'` as an option on files. An example usage is below:

```javascript
files: [
  { 
    src: [ 'my-test.js' ],
    type: 'module',
    served: true,
    included: true,
    watched: true
  }
]
```