### PR TITLE
fix(karma): accept karma 6.x in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "grunt": ">=0.4.x",
-    "karma": "^4.0.0 || ^5.0.0"
+    "karma": "^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Follows-up https://github.com/karma-runner/grunt-karma/pull/297.

Fixes https://github.com/karma-runner/grunt-karma/issues/294.